### PR TITLE
fixed nan checking

### DIFF
--- a/js/directives/mqttTimeSeries.js
+++ b/js/directives/mqttTimeSeries.js
@@ -19,11 +19,11 @@ angular.module('Mqtt.Controls')
       ],
       link: function(scope, element, attributes, mqttPanelController) {
         var maxPoints = 20;
-        if (attributes.maxPoints && parseInt(attributes.maxPoints) != NaN) {
+        if (attributes.maxPoints && !isNaN(parseInt(attributes.maxPoints))) {
           maxPoints = parseInt(attributes.maxPoints);
         }
         var interval = 500;
-        if (attributes.interval && parseInt(attributes.interval) != NaN) {
+        if (attributes.interval && !isNaN(parseInt(attributes.interval))) {
           interval = parseInt(attributes.interval);
         }
         scope.curValue = 0;


### PR DESCRIPTION
Yeah, one of the bad parts of JavaScript:
```bash
[a0viedo@arya MQTT-bootstrap]$ node
> NaN == NaN
false
> isNaN(NaN)
true

```
